### PR TITLE
Add-ViewTotalNumber

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -14,11 +14,11 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
 
-
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS);
+        int x = model.updateFilteredPersonListSize(PREDICATE_SHOW_ALL_PERSONS);
+        String feedback = MESSAGE_SUCCESS + " " + x + " contacts found";
+        return new CommandResult(feedback);
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -84,4 +84,11 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * has the same functionality as updateFilteredPersonList as above, but returns the size of the new list
+     * @param predicate
+     * @return int size of the updated list
+     */
+    int updateFilteredPersonListSize(Predicate<Person> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -129,6 +129,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public int updateFilteredPersonListSize(Predicate<Person> predicate) {
+        filteredPersons.setPredicate(predicate);
+        return filteredPersons.size();
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -67,8 +67,13 @@ public class LogicManagerTest {
     @Test
     public void execute_validCommand_success() throws Exception {
         String listCommand = ListCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        int count = model.getFilteredPersonList().size();
+        String expectedMessage = String.format("%s %d contacts found",
+                ListCommand.MESSAGE_SUCCESS, count);
+        assertCommandSuccess(listCommand, expectedMessage, model);
     }
+
 
     @Test
     public void execute_storageThrowsIoException_throwsCommandException() {
@@ -94,12 +99,13 @@ public class LogicManagerTest {
      * - the internal model manager state is the same as that in {@code expectedModel} <br>
      * @see #assertCommandFailure(String, Class, String, Model)
      */
-    private void assertCommandSuccess(String inputCommand, String expectedMessage,
-            Model expectedModel) throws CommandException, ParseException {
+    private void assertCommandSuccess(String inputCommand, String expectedMessage, Model expectedModel)
+            throws CommandException, ParseException {
         CommandResult result = logic.execute(inputCommand);
         assertEquals(expectedMessage, result.getFeedbackToUser());
         assertEquals(expectedModel, model);
     }
+
 
     /**
      * Executes the command, confirms that a ParseException is thrown and that the result message is correct.

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -157,6 +157,11 @@ public class AddCommandTest {
         public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public int updateFilteredPersonListSize(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -28,12 +28,21 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        int count = expectedModel.getFilteredPersonList().size();
+        String expectedMessage = String.format("%s %d contacts found",
+                ListCommand.MESSAGE_SUCCESS, count);
+
+        assertCommandSuccess(new ListCommand(), model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+
+        int count = expectedModel.getFilteredPersonList().size();
+        String expectedMessage = String.format("%s %d contacts found",
+                ListCommand.MESSAGE_SUCCESS, count);
+
+        assertCommandSuccess(new ListCommand(), model, expectedMessage, expectedModel);
     }
 }


### PR DESCRIPTION
**PR documentation for #52 view total number of contacts**

"list" command does not return a meaningful message nor provide any useful information.

Let's modify it so that the user knows how many contacts he has in the listed contacts.
 
**changes**
Adjust current "list" command to display number of contacts in the addressbook. 
Modify testcases to assert against correct message.

**Specifics**
*ModelManager*: Added new method ```java public int updateFilteredPersonListSize(Predicate<Person> predicate)``` that updates the list according the the predicate just like ```java public void updateFilteredPersonList(Predicate<Person> predicate)```, but returns the size of the new list as an int.
*Model*: Added the matching abstract method as the API
*ListCommand*: execute now calls updateFilteredPersonListSize in its body to obtain the number, then adds it to the user feedback message. 


Fixes #52 