### PR TITLE
Fix issue with some commands not resetting status texts 

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
@@ -18,6 +19,10 @@ public class ClearCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
-        return new CommandResult(MESSAGE_SUCCESS);
+        // Clear wipes existing sorts/filters and starts on clean slate
+        model.updateDisplayList(PREDICATE_SHOW_ALL_PERSONS);
+        model.clearSorting();
+
+        return new CommandResult(MESSAGE_SUCCESS, false, false, "", "");
     }
 }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -23,6 +23,8 @@ public class CommandResult {
 
     /**
      * Constructs a {@code CommandResult} with the specified fields and Status Text
+     * @param sortStatusText sort status text to be updated, only updated if non-null
+     * @param findStatusText find status text to be updated, only updated if non-null
      */
     public CommandResult(String feedbackToUser, boolean showHelp, boolean exit,
             String sortStatusText, String findStatusText) {
@@ -33,6 +35,7 @@ public class CommandResult {
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
+     * Does not update sort or find status text
      */
     public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
@@ -43,6 +46,7 @@ public class CommandResult {
     /**
      * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
      * and other fields set to their default value.
+     * Does not update sort or find status text
      */
     public CommandResult(String feedbackToUser) {
         this(feedbackToUser, false, false);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -91,7 +91,9 @@ public class EditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateDisplayList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
+        return new CommandResult(
+                String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)),
+                false, false, null, "");
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -21,6 +21,6 @@ public class ListCommand extends Command {
         model.clearSorting();
         int contactCount = model.getPersonListSize();
         String feedback = MESSAGE_SUCCESS + " " + contactCount + " contacts found";
-        return new CommandResult(feedback, false, false, "", null);
+        return new CommandResult(feedback, false, false, "", "");
     }
 }


### PR DESCRIPTION
Fixes #181 
Clear, edit, list now reset the find status text.

Note: Clear command now resets sort order and find predicate to restart addressbook to clean slate